### PR TITLE
Use 64-bit Python builds on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,13 @@
 version: build-{build}-{branch}
 
+# https://www.appveyor.com/docs/lang/python/
+image:
+  - Visual Studio 2019
+
 environment:
   matrix:
-    # https://www.appveyor.com/docs/installed-software#python lists available
-    # versions
+    # https://www.appveyor.com/docs/windows-images-software/#python lists
+    # available versions
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,12 @@ environment:
   matrix:
     # https://www.appveyor.com/docs/installed-software#python lists available
     # versions
-    - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python37"
-    - PYTHON: "C:\\Python38"
-    - PYTHON: "C:\\Python39"
-    - PYTHON: "C:\\Python310"
-    - PYTHON: "C:\\Python311"
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python37-x64"
+    - PYTHON: "C:\\Python38-x64"
+    - PYTHON: "C:\\Python39-x64"
+    - PYTHON: "C:\\Python310-x64"
+    - PYTHON: "C:\\Python311-x64"
 
 init:
   - "echo %PYTHON%"


### PR DESCRIPTION
The Zope project no longer builds and uploads 32-bit Windows wheels to PyPI.