### PR TITLE
Upgrade to a newer pypy3 version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "pypy3.7"
+          - "pypy3.10"
 
     steps:
       - name: Install OS dependencies


### PR DESCRIPTION
pypy3.7 (7.3.9) [fails](https://github.com/mgedmin/zodbbrowser/actions/runs/7429640681/job/20218464319) to import lxml (5.0.1) with

    Traceback (most recent call last):
      File "/home/runner/work/zodbbrowser/zodbbrowser/src/zodbbrowser/ftests/test_standalone.py", line 15, in <module>
        from lxml.html import fromstring, tostring
      File "/opt/hostedtoolcache/PyPy/3.7.13/x64/site-packages/lxml/html/__init__.py", line 53, in <module>
        from .. import etree
      File "src/lxml/etree.pyx", line 1, in init lxml.etree
    TypeError: inheritance from PyVarObject types like 'str' not currently supported

Let's see if a newer PyPy3 can handle it.